### PR TITLE
improve contributing.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+* use github's [node `.gitignore`](https://github.com/github/gitignore/edit/master/Node.gitignore)
+* improve `CONTRIBUTING.md` to be useful for contributors as well as collaborators
+
 ## 0.3.1
 * change `standard` devDep to always use latest ([#7](https://github.com/ngoldman/module-init/issues/7))
 * add linter options ([#8](https://github.com/ngoldman/module-init/issues/8))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,34 @@
-# Open-2 Contributing Guidelines
+# Contributing Guidelines
+
+Contributions welcome! Please check past issues and pull requests before you open your own issue or pull request to avoid duplicating a frequently asked question.
+
+In addition to improving the project, refactoring code, and implementing features, this project welcomes the following types of contributions:
+
+- **Ideas**: participate in an issue thread or start your own to have your voice heard.
+- **Writing**: contribute your expertise in an area by helping expand the included content.
+- **Copy editing**: fix typos, clarify language, and generally improve the quality of the content.
+- **Formatting**: help keep content easy to read with consistent formatting.
+
+## Install
+
+Fork and clone the repo, then `npm install` to install all dependencies.
+
+## Testing
+
+Tests are run with `npm test`. Please ensure all tests are passing before submitting a pull request (unless you're creating a failing test to increase test coverage or show a problem).
+
+## Code Style
+
+[![standard][standard-image]][standard-url]
+
+This repository uses [`standard`][standard-url] to maintain code style and consistency and avoid style arguments. `npm test` runs `standard` so you don't have to!
+
+[standard-image]: https://cdn.rawgit.com/feross/standard/master/badge.svg
+[standard-url]: https://github.com/feross/standard
+
+---
+
+# Collaborating Guidelines
 
 **This is an OPEN Open Source Project.**
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This module is functional, but still under active development. The idea is to au
 | `git init` | ✓ |
 | `README.md` w/ title, desc, npm & travis badges, install, usage, contributing, license | ✓ |
 | `CHANGELOG.md` using [keepachangelog](http://keepachangelog.com/) style | ✓ |
-| `CONTRIBUTING.md` using [`open-2-contributing`](https://github.com/ngoldman/open-2-contributing) template | ✓ |
+| `CONTRIBUTING.md` | ✓ |
 | `LICENSE.md` using [ISC](http://en.wikipedia.org/wiki/ISC_license) | ✓ |
 | `package.json` fully filled out | ✓ |
 | [`standard`](https://github.com/feross/standard) & [`faucet`](https://github.com/substack/faucet) added as dev dependencies and set as test script | ✓ |
@@ -68,7 +68,7 @@ var data = {
   usrGithub: 'githubUsername'       // required
   pkgDescription: 'description',    // optional
   pkgKeywords: 'one, two, three',   // optional
-  pkgContributing: 'Open-2',        // optional
+  pkgContributing: true,            // optional
   pkgLinter: 'standard',            // optional, default: standard
   pkgLicense: 'ISC',                // optional, default: ISC
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -62,10 +62,10 @@ var questions = [{
   default: 'ISC'
 },
 {
-  type: 'input',
+  type: 'confirm',
   name: 'pkgContributing',
   message: 'contributing',
-  default: 'Open-2'
+  default: true
 },
 {
   type: 'list',

--- a/templates/CONTRIBUTING.md.mustache
+++ b/templates/CONTRIBUTING.md.mustache
@@ -1,4 +1,36 @@
-# Open-2 Contributing Guidelines
+# Contributing Guidelines
+
+Contributions welcome! Please check past issues and pull requests before you open your own issue or pull request to avoid duplicating a frequently asked question.
+
+In addition to improving the project, refactoring code, and implementing features, this project welcomes the following types of contributions:
+
+- **Ideas**: participate in an issue thread or start your own to have your voice heard.
+- **Writing**: contribute your expertise in an area by helping expand the included content.
+- **Copy editing**: fix typos, clarify language, and generally improve the quality of the content.
+- **Formatting**: help keep content easy to read with consistent formatting.
+
+## Install
+
+Fork and clone the repo, then `npm install` to install all dependencies.
+
+## Testing
+
+Tests are run with `npm test`. Please ensure all tests are passing before submitting a pull request (unless you're creating a failing test to increase test coverage or show a problem).
+
+## Code Style
+
+[![{{pkgLinter}}][{{pkgLinter}}-image]][{{pkgLinter}}-url]
+
+This repository uses [`{{pkgLinter}}`][{{pkgLinter}}-url] to maintain code style and consistency and avoid style arguments. `npm test` runs `{{pkgLinter}}` so you don't have to!
+
+[standard-image]: https://cdn.rawgit.com/feross/standard/master/badge.svg
+[standard-url]: https://github.com/feross/standard
+[semistandard-image]: https://cdn.rawgit.com/flet/semistandard/master/badge.svg
+[semistandard-url]: https://github.com/Flet/semistandard
+
+---
+
+# Collaborating Guidelines
 
 **This is an OPEN Open Source Project.**
 

--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -24,7 +24,7 @@ var {{nodeName}} = require('{{pkgName}}')
 
 ## Contributing
 
-[{{pkgContributing}}](CONTRIBUTING.md)
+Contributions welcome! Please read the [contributing guidelines](CONTRIBUTING.md) first.
 
 ## License
 


### PR DESCRIPTION
makes the contributing.md template (and the project's contributing.md) more useful for contributors as well as collaborators. `open-2` doesn't really cover people who aren't direct collaborators.