### PR TITLE
Use tap-spec 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "standard": "^4.2.1",
-    "tap-spec": "^3.0.0",
+    "tap-spec": "^4.0.2",
     "tape": "^4.0.0"
   },
   "homepage": "https://github.com/ngoldman/module-init",

--- a/templates/package.json.mustache
+++ b/templates/package.json.mustache
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "{{pkgLinter}}": "*",
-    "tap-spec": "^3.0.0",
+    "tap-spec": "^4.0.2",
     "tape": "^4.0.0"
   },
   "homepage": "https://github.com/{{usrGithub}}/{{pkgName}}",


### PR DESCRIPTION
tap-spec `3.0` had some rendering issues when tests failed. `4.0` fixes a lot of these issues and cleans up the output a bit more.