### PR TITLE
can haz package name

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,6 +5,8 @@ var path = require('path')
 var chalk = require('chalk')
 var config = require('git-config').sync()
 var inquirer = require('inquirer')
+var canHazPackage = require('can-haz-package')
+
 var clopts = require('cliclopts')([
   {
     name: 'version',
@@ -67,44 +69,45 @@ var questions = [{
   type: 'input',
   name: 'pkgName',
   message: 'name',
-  default: path.basename(process.cwd())
+  default: path.basename(process.cwd()),
+  validate: canHazPackage
 },
-{
-  type: 'input',
-  name: 'pkgVersion',
-  message: 'version',
-  default: '1.0.0'
-},
-{
-  type: 'input',
-  name: 'pkgDescription',
-  message: 'description'
-},
-{
-  type: 'input',
-  name: 'pkgKeywords',
-  message: 'keywords'
-},
-{
-  type: 'list',
-  name: 'pkgLicense',
-  message: 'license',
-  choices: ['ISC', 'Apache-2.0'],
-  default: 'ISC'
-},
-{
-  type: 'confirm',
-  name: 'pkgContributing',
-  message: 'contributing',
-  default: true
-},
-{
-  type: 'list',
-  name: 'pkgLinter',
-  message: 'linter',
-  choices: ['standard', 'semistandard'],
-  default: 'standard'
-}]
+  {
+    type: 'input',
+    name: 'pkgVersion',
+    message: 'version',
+    default: '1.0.0'
+  },
+  {
+    type: 'input',
+    name: 'pkgDescription',
+    message: 'description'
+  },
+  {
+    type: 'input',
+    name: 'pkgKeywords',
+    message: 'keywords'
+  },
+  {
+    type: 'list',
+    name: 'pkgLicense',
+    message: 'license',
+    choices: ['ISC', 'Apache-2.0'],
+    default: 'ISC'
+  },
+  {
+    type: 'confirm',
+    name: 'pkgContributing',
+    message: 'contributing',
+    default: true
+  },
+  {
+    type: 'list',
+    name: 'pkgLinter',
+    message: 'linter',
+    choices: ['standard', 'semistandard'],
+    default: 'standard'
+  }]
 
 inquirer.prompt(questions, function (data) {
   data.usrName = config.user.name

--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ var OPTIONS = {
     pkgLinter: ['standard', 'semistandard']
   },
   defaults: {
-   'pkgContributing': true,
-    pkgLicense: 'ISC',
-    pkgLinter: 'standard'
+    'pkgContributing': true,
+    'pkgLicense': 'ISC',
+    'pkgLinter': 'standard'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "camel-case": "^1.1.1",
+    "can-haz-package": "^1.0.1",
     "chalk": "^1.0.0",
     "cliclopts": "^1.1.0",
     "cwp": "^0.2.1",


### PR DESCRIPTION
Closes #17 

This PR adds a check that will ensure the package name:
1. conforms to the npm naming conventions
2. does not already exist as a published package

![blahhhhhhhhhhhhh](https://cloud.githubusercontent.com/assets/360233/9050027/90811d06-3a0e-11e5-945e-e8a6e580f8d9.gif)

This PR leverages a package I created for this purpose: https://github.com/flet/can-haz-package