### PR TITLE
add 0.10 and 0.12 for max test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   - 'stable'
+  - '0.12'
+  - '0.10'
 sudo: false
 cache:
   directories:
     - node_modules
-script:
-  - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+* add 0.10 and 0.12 back to travis
+* remove redundant `script` section of travis (default is already `npm test`)
+
 ## [1.3.2] - 2015-09-22
 * remove can-haz-package from dependencies (oops)
 * fix bad reference to `package.json`

--- a/templates/.travis.yml.mustache
+++ b/templates/.travis.yml.mustache
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   - 'stable'
+  - '0.12'
+  - '0.10'
 sudo: false
 cache:
   directories:
     - node_modules
-script:
-  - npm test


### PR DESCRIPTION
addresses discussion in #25

based on:

> Tweet from seldo a few days ago:
> 
> Major(ish) node versions, requests in last 7 days:
> 0.12 779 MM
> 0.10 732 MM
> 4 222 MM
> 2 22 MM
> 3 19 MM
> 1 6 MM

Top 3 makes sense with those numbers.