### PR TITLE
fix keywords being escaped

### DIFF
--- a/templates/package.json.mustache
+++ b/templates/package.json.mustache
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/{{usrGithub}}/{{pkgName}}",
   "license": "{{pkgLicense}}",
-  "keywords": [{{pkgKeywords}}],
+  "keywords": [{{{pkgKeywords}}}],
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,8 @@ test('create things as expected', function (t) {
       var file = path.resolve('test/dummy-module/package.json')
       var exists = fs.existsSync(file)
       console.log(file, exists)
+      var pkgJson = require(file)
+      t.deepEquals(pkgJson.keywords, ['hello', 'world'], 'keywords in package.json are correct')
       t.ok(res, 'got response')
       t.ok(exists, 'directory exists')
       rimraf.sync('test/dummy-module')

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ var testData = {
   pkgDescription: 'desc',
   pkgLicense: 'ISC',
   pkgContributing: true,
+  pkgKeywords: '"hello", "world"',
   pkgLinter: 'standard',
   usrName: 'BOB',
   usrEmail: 'BOB@hotmail.com',


### PR DESCRIPTION
I was getting explosions when adding keywords. The `package.json` had this in it:

```
"keywords": [&quot;git&quot;, &quot;clone&quot;, &quot;pull&quot;, &quot;gotta&quot;, &quot;get&quot;, &quot;em&quot;, &quot;all&quot;, &quot;pokemon&quot;],
```
So, it looks like `mustache` is escaping characters by default. This must be different behavior than `micromustache`.

This PR fixes it by adding another set of  'staches around pkgKeywords in `package.json.mustache`.

