### PR TITLE
Add standard/semistandard badges to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 
 [![npm][npm-image]][npm-url]
 [![travis][travis-image]][travis-url]
+[![standard][standard-image]][standard-url]
 
 [npm-image]: https://img.shields.io/npm/v/module-init.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/module-init
 [travis-image]: https://img.shields.io/travis/ngoldman/module-init.svg?style=flat-square
 [travis-url]: https://travis-ci.org/ngoldman/module-init
+[standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat
+[standard-url]: http://standardjs.com/
 
 Command-line tool to quickly create a new node module with readme, license, contributing guidelines, and other goodies.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [npm-url]: https://www.npmjs.com/package/module-init
 [travis-image]: https://img.shields.io/travis/ngoldman/module-init.svg?style=flat-square
 [travis-url]: https://travis-ci.org/ngoldman/module-init
-[standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat
+[standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square
 [standard-url]: http://standardjs.com/
 
 Command-line tool to quickly create a new node module with readme, license, contributing guidelines, and other goodies.

--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -8,7 +8,7 @@
 [npm-url]: https://www.npmjs.com/package/{{pkgName}}
 [travis-image]: https://img.shields.io/travis/{{usrGithub}}/{{pkgName}}.svg?style=flat-square
 [travis-url]: https://travis-ci.org/{{usrGithub}}/{{pkgName}}
-[standard-image]: https://img.shields.io/badge/code%20style-{{pkgLinter}}-brightgreen.svg?style=flat
+[standard-image]: https://img.shields.io/badge/code%20style-{{pkgLinter}}-brightgreen.svg?style=flat-square
 [standard-url]: http://npm.im/{{pkgLinter}}
 
 {{#pkgDescription}}

--- a/templates/README.md.mustache
+++ b/templates/README.md.mustache
@@ -2,11 +2,14 @@
 
 [![npm][npm-image]][npm-url]
 [![travis][travis-image]][travis-url]
+[![standard][standard-image]][standard-url]
 
 [npm-image]: https://img.shields.io/npm/v/{{pkgName}}.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/{{pkgName}}
 [travis-image]: https://img.shields.io/travis/{{usrGithub}}/{{pkgName}}.svg?style=flat-square
 [travis-url]: https://travis-ci.org/{{usrGithub}}/{{pkgName}}
+[standard-image]: https://img.shields.io/badge/code%20style-{{pkgLinter}}-brightgreen.svg?style=flat
+[standard-url]: http://npm.im/{{pkgLinter}}
 
 {{#pkgDescription}}
 


### PR DESCRIPTION
I haven't tested this out (I'm doing it all from the web), but it should add either standard or semistandard badges to all generated READMEs as well as this project's README.