### PR TITLE
Move linting to the end of the test chain

### DIFF
--- a/templates/package.json.mustache
+++ b/templates/package.json.mustache
@@ -20,6 +20,6 @@
     "url": "https://github.com/{{usrGithub}}/{{pkgName}}.git"
   },
   "scripts": {
-    "test": "{{pkgLinter}} && tape test/*.js | tap-spec"
+    "test": "tape test/*.js | tap-spec && {{pkgLinter}}"
   }
 }


### PR DESCRIPTION
Hypotheses: Style linting is important, but sometimes it just gets in the way when writing tests.  Moving our linting to the end of the test chain helps avoid unnecessary style enforcement when writing tests.

Linting can help catch errors, but more often than not it's better to address those errors after running the test suite.